### PR TITLE
Refactoring variable name in test method

### DIFF
--- a/tests/Unit/IsValidHourTest.php
+++ b/tests/Unit/IsValidHourTest.php
@@ -67,7 +67,7 @@ final class IsValidHourTest extends TestCase
      *
      * @dataProvider provideHours
      */
-    public function testIsValidHour(int $Hour, bool $expectedResult): void
+    public function testIsValidHour(int $hour, bool $expectedResult): void
     {
         $reflectionMethod = (new ReflectionClass(StringManipulation::class))->getMethod('isValidHour');
 
@@ -78,7 +78,7 @@ final class IsValidHourTest extends TestCase
          */
         $reflectionMethod->setAccessible(true);
 
-        $result = $reflectionMethod->invoke(null, $Hour);
+        $result = $reflectionMethod->invoke(null, $hour);
 
         self::assertSame($expectedResult, $result);
     }


### PR DESCRIPTION
The changes in the code are focused on refactoring the variable name in the `testIsValidHour` method of the `IsValidHourTest` class. The variable `$Hour` has been renamed to `$hour` to follow the standard naming conventions in PHP, which prefer camelCase or snake_case for variable names. This change improves the readability and consistency of the code.