### PR TITLE
(Fixed) Refactor release creation conditions in GitHub workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+language: "en"
+early_access: true
+reviews:
+    request_changes_workflow: true
+    high_level_summary: true
+    poem: false
+    review_status: true
+    collapse_walkthrough: true
+    auto_review:
+        enabled: true
+        ignore_title_keywords:
+            - "WIP"
+            - "DO NOT MERGE"
+        drafts: false
+        base_branches:
+            - "develop"
+            - "feat/.*"
+            - "main"
+chat:
+    auto_reply: true

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -179,7 +179,7 @@ jobs:
       # This step gets the commit messages between the latest tag and the HEAD.
       - name: Get commit messages
         id: get-commits
-        if: github.ref == 'refs/heads/main' && steps.compare-link.outcome == 'success'
+        if: github.ref == 'refs/heads/main' && steps.comparison-link.outcome == 'success'
         run: |
           # Capture the output of git log command
           GIT_LOG_OUTPUT=$(git log $LATEST_TAG..HEAD --pretty=format:'%h - %s')
@@ -192,7 +192,7 @@ jobs:
       # This step creates a new release with the new tag and the commit messages as the body.
       - name: Create release
         id: create_release
-        if: github.ref == 'refs/heads/main' && steps.push-tag.outcome == 'success' && steps.get-commits.outcome == 'success'
+        if: github.ref == 'refs/heads/main' && steps.get-commits.outcome == 'success'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 2024-02-24
 
+### Fixed
+- Corrected the conditions for invoking the 'Create Release' step in the GitHub workflow. The step now triggers only when the 'Get Commits' step is successful, enhancing the reliability of the release process.
+- Fixed a misnamed step reference in the 'Get commit messages' step, changing 'compare-link' to 'comparison-link.outcome', ensuring it triggers correctly.
+
+## 2024-02-24
+
 ### Changed
 - Refactored conditions in several GitHub workflow steps to ensure accurate execution flow. This change enhances the reliability and efficiency of the CI/CD pipeline by aligning execution conditions with the expected workflow progression.
 - Improved the readability and maintainability of the workflow file by ensuring conditionals are logically structured and directly relevant to their respective steps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 - Corrected the conditions for invoking the 'Create Release' step in the GitHub workflow. The step now triggers only when the 'Get Commits' step is successful, enhancing the reliability of the release process.
 - Fixed a misnamed step reference in the 'Get commit messages' step, changing 'compare-link' to 'comparison-link.outcome', ensuring it triggers correctly.
 
-## 2024-02-24
-
 ### Changed
 - Refactored conditions in several GitHub workflow steps to ensure accurate execution flow. This change enhances the reliability and efficiency of the CI/CD pipeline by aligning execution conditions with the expected workflow progression.
 - Improved the readability and maintainability of the workflow file by ensuring conditionals are logically structured and directly relevant to their respective steps.


### PR DESCRIPTION
## **User description**
## Summary

This MR introduces a critical fix to the GitHub Actions workflow for PHP projects, explicitly addressing the conditions under which the 'Create Release' step is triggered. Previously, a misnamed step reference caused this process to malfunction. Now, the release creation step correctly depends on the success of the 'Get Commits' step, enhancing the reliability and accuracy of the release process.

### Context and Background

During routine checks, it was discovered that the release creation step in our CI/CD pipeline occasionally failed to trigger as expected. This issue was traced to an incorrect step reference within the workflow conditions.

### Problem Description

The GitHub workflow was configured to create a new release only if certain conditions were met, including the success of a step referred to as 'comparison-link'. However, this reference needed to be corrected, leading to situations where the release creation step would not execute, even when it should have.

### Solution Description

The solution involved correcting the step reference within the workflow file from 'comparison-link' to 'comparison-link.outcome', ensuring that the 'Create Release' step is only triggered after successfully completing the 'Get Commits' step. This adjustment ensures a more stable and predictable release process.

### List of Changes

- **Fixed**: `.github/workflows/php.yml` - Corrected the conditional check for the 'Create Release' step to rely on the correct outcome of the 'Get Commits' step. This involved changing the step reference from 'comparison-link' to 'comparison-link.outcome'.


___

## **Type**
bug_fix


___

## **Description**
- Corrected the step reference in the 'Get commit messages' step from 'compare-link' to 'comparison-link.outcome', ensuring it triggers correctly.
- Simplified the 'Create release' step's condition to only require the 'Get commits' step's success, making the workflow more reliable.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>php.yml</strong><dd><code>Fix and Simplify Release Creation Conditions in GitHub Workflow</code></dd></summary>
<hr>
      
.github/workflows/php.yml

<li>Corrected the condition for the 'Get commit messages' step to check <br>the outcome of 'comparison-link' instead of 'compare-link'.<br> <li> Simplified the condition for the 'Create release' step to only depend <br>on the success of the 'Get commits' step.<br>


</details>
    

  </td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/8/files#diff-a73bb6555480a5ee79ae276a3f5d71a08fa316e09a4a8da7b643cf1e92c97df9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved reliability and readability of GitHub workflow steps for internal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->