### PR TITLE
(Changed) Exclude meta files from project exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,10 +5,12 @@
 /tests              export-ignore
 
 # Exclude meta files from archives
+/.coderabbit.yaml   export-ignore
 /.gitattributes     export-ignore
 /.github            export-ignore
 /.gitignore         export-ignore
 /.phan              export-ignore
+/.pr_agent.toml     export-ignore
 /.qodana            export-ignore
 /.vscode            export-ignore
 /composer.lock      export-ignore


### PR DESCRIPTION
## Summary

This merge request updates the `.gitattributes` file to exclude two additional meta files, `.coderabbit.yaml` and `.pr_agent.toml`, from project exports. By adding these files to the `export-ignore` list, we ensure that they are not included in distributions, maintaining a focus on the main project files.

### Context and Background

The `.gitattributes` file defines how the repository's contents are handled, especially in exports. Previously, certain meta files were already being excluded from exports to keep the distribution clean and focused on the essential project files. Extending this list to include `.coderabbit.yaml` and `.pr_agent.toml` continues this practice, addressing the need for streamlined project distributions.

### Problem Description

Before this update, `.coderabbit.yaml` and `.pr_agent.toml` were included in project exports. These files, while valuable for development and repository management, are optional for the project's operation. Their export inclusion could lead to unnecessary bloat and potential confusion regarding the project's core components.

### Solution Description

By marking `.coderabbit.yaml` and `.pr_agent.toml` with the `export-ignore` attribute in the `.gitattributes` file, we exclude them from any archives generated from the repository, such as ZIP or TAR files. This decision keeps the project distributions lean and focused solely on operational components, enhancing clarity and reducing the potential for confusion.

### List of Changes

- chore: Exclude `.coderabbit.yaml` and `.pr_agent.toml` from project exports by adding them to the `export-ignore` list in `.gitattributes`.