### PR TITLE
(Fixed) Remove invalid registries section from config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,7 @@
 version: 2
-registries:
-  packagist:
-    type: composer-repository
-    url: "https://repo.packagist.org"
 updates:
   - package-ecosystem: "composer"
     directory: "/"
-    registries:
-      - packagist
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
### **User description**
## Summary

This pull request fixes a Dependabot configuration error by removing the invalid registries block from `.github/dependabot.yml`. The change ensures that Dependabot parses the configuration correctly and continues to update dependencies from the public Packagist repository without requiring unnecessary authentication.

### Context and Background

Dependabot automates dependency updates for our PHP package. The original configuration included a custom registries section for Packagist using the `composer-repository` type. This type mandates both a `username` and a `password`—credentials that are unnecessary for public repositories. Dependabot documentation indicates that custom registry configuration is only required for private repositories.

### Problem Description

The `.github/dependabot.yml` file contained a registries block that defined Packagist without the required authentication properties. This misconfiguration led to parsing errors that prevented Dependabot from functioning as intended, thereby halting automated dependency updates.

### Solution Description

The solution removes the erroneous registries block from the configuration file. By doing so, Dependabot defaults to using the public Packagist repository without any authentication, resolving the parsing issue and restoring normal operation.

### List of Changes

- fix: Remove invalid registries block from `.github/dependabot.yml`


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Removed invalid `registries` block from `.github/dependabot.yml`.

- Fixed Dependabot configuration parsing error for public Packagist.

- Ensured automated dependency updates function correctly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Removed invalid registries block from Dependabot config</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<li>Removed <code>registries</code> block defining Packagist with missing credentials.<br> <li> Simplified configuration to use public Packagist repository.<br> <li> Ensured Dependabot operates without parsing errors.


</details>


  </td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/41/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management settings by removing outdated custom registry configurations to streamline package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->