### PR TITLE
(Changed) Update to PHP 8.3 and Enforce Explicit Type Declarations

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,10 +9,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up php 8.2
+      - name: Set up php 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.3"
           extensions: mbstring, xml, zip, pdo_mysql, xhprof
 
       - name: Install dependencies

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ["8.2", "8.3", "8.4"]
+        php-versions: ["8.3", "8.4"]
 
     steps:
       # This step checks out a copy of your repository.

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -54,8 +54,8 @@ return [
     //
     // Note that the **only** effect of choosing `'5.6'` is to infer that functions removed in php 7.0 exist.
     // (See `backward_compatibility_checks` for additional options)
-    // Automatically inferred from composer.json requirement for "php" of "^8.2"
-    'target_php_version' => '8.2',
+    // Automatically inferred from composer.json requirement for "php" of "^8.3"
+    'target_php_version' => '8.3',
 
     // If enabled, missing properties will be created when
     // they are first seen. If false, we'll report an

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ And to run tests matching a specific name pattern:
 
 ## System Requirements
 
-- PHP 8.2 or later.
+- PHP 8.3 or later.
 
 ## Support
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php": ">=8.2.0|>=8.3.0|>=8.4.0"
+    "php": ">=8.3.0|>=8.4.0"
   },
   "require-dev": {
     "enlightn/security-checker": ">=2.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
     level: max
-    phpVersion: 80200
+    phpVersion: 80300
     treatPhpDocTypesAsCertain: false
     tipsOfTheDay: false
     reportWrongPhpDocTypeInVarTag: true

--- a/rector.php
+++ b/rector.php
@@ -43,17 +43,17 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(SeparateMultiUseImportsRector::class);
     $rectorConfig->rule(SplitDoubleAssignRector::class);
 
-    $rectorConfig->phpVersion(PhpVersion::PHP_82);
+    $rectorConfig->phpVersion(PhpVersion::PHP_83);
 
     // define sets of rules
     $rectorConfig->sets(
         [
-            LevelSetList::UP_TO_PHP_82,
+            LevelSetList::UP_TO_PHP_83,
             SetList::CODE_QUALITY,
             SetList::CODING_STYLE,
             SetList::DEAD_CODE,
             SetList::EARLY_RETURN,
-            SetList::PHP_82,
+            SetList::PHP_83,
             SetList::TYPE_DECLARATION,
             SetList::NAMING,
             SetList::PRIVATIZATION,

--- a/src/AccentNormalization.php
+++ b/src/AccentNormalization.php
@@ -25,10 +25,8 @@ trait AccentNormalization
     /**
      * An array of characters with accents and special characters. These characters are intended to be replaced
      * in a string to normalize it.
-     *
-     * @var string[]
      */
-    private const REMOVE_ACCENTS_FROM = [
+    private const array REMOVE_ACCENTS_FROM = [
         '*',
         '?',
         '’',
@@ -271,10 +269,8 @@ trait AccentNormalization
     /**
      * An array of characters without accents. These characters correspond to the characters in the
      * REMOVE_ACCENTS_FROM array and are used to replace them in a string.
-     *
-     * @var string[]
      */
-    private const REMOVE_ACCENTS_TO = [
+    private const array REMOVE_ACCENTS_TO = [
         ' ',
         ' ',
         "'",

--- a/src/StringManipulation.php
+++ b/src/StringManipulation.php
@@ -194,7 +194,7 @@ class StringManipulation
      * processing text for storage in a database or file system that does not support UTF-8 encoding.
      *
      * @param null|string $valor The input string to be converted from UTF-8 to ANSI. If null, the function will return
-     *                           an empty string.
+     *                            an empty string.
      *
      * @return string The converted string in ANSI encoding.
      *
@@ -282,7 +282,7 @@ class StringManipulation
      *
      * @param string $date The date string to validate. This should be a string representing a date.
      * @param string $format The expected date format. Default is 'Y-m-d H:i:s'. This should be a string representing
-     *                       the expected format of the date.
+     *                        the expected format of the date.
      *
      * @return bool Returns true if the date string matches the format and is logically valid, false otherwise.
      *

--- a/src/UnicodeMappings.php
+++ b/src/UnicodeMappings.php
@@ -24,10 +24,8 @@ trait UnicodeMappings
     /**
      * An associative array mapping Unicode characters to their ANSI counterparts.
      * The keys of the array are Unicode characters, and the values are the corresponding ANSI characters.
-     *
-     * @var array<string, string>
      */
-    private const UTF8_ANSI2 = [
+    private const array UTF8_ANSI2 = [
         '\u00c0' => 'À',
         '\u00c1' => 'Á',
         '\u00c2' => 'Â',

--- a/tests/Unit/IsValidDateTest.php
+++ b/tests/Unit/IsValidDateTest.php
@@ -15,9 +15,9 @@ use PHPUnit\Framework\TestCase;
  */
 final class IsValidDateTest extends TestCase
 {
-    private const DATE_TIME_FORMAT = 'Y-m-d H:i:s';
+    private const string DATE_TIME_FORMAT = 'Y-m-d H:i:s';
 
-    private const TIME_FORMAT = 'H:i:s';
+    private const string TIME_FORMAT = 'H:i:s';
 
 
     /**
@@ -28,6 +28,7 @@ final class IsValidDateTest extends TestCase
      * @psalm-return list{list{'2023-09-06 12:30:00', 'Y-m-d H:i:s'}, list{'06-09-2023', 'd-m-Y'}, list{'2023-09-06',
      *     'Y-m-d'}, list{'2012-02-28', 'Y-m-d'}, list{'00:00:00', 'H:i:s'}, list{'23:59:59', 'H:i:s'},
      *     list{'29-02-2012', 'd-m-Y'}, list{'28-02-2023', 'd-m-Y'}, list{'2023-02-28', 'Y-m-d'}}
+     *
      * @suppress PossiblyUnusedMethod
      */
     public static function provideValidDates(): array

--- a/tests/Unit/NameFixTest.php
+++ b/tests/Unit/NameFixTest.php
@@ -27,7 +27,6 @@ final class NameFixTest extends TestCase
     {
         // Basic and advanced name handling
         $names = [
-            'o’reilly' => "O'reilly",
             'de la hoya' => 'de la Hoya',
             'de la tòrré' => 'de la Torre',
             'donald' => 'Donald',
@@ -45,6 +44,7 @@ final class NameFixTest extends TestCase
             ' mcDonald ' => 'McDonald',
             'Mc donald' => 'Mc Donald',
             'mcdónald' => 'McDonald',
+            'o’reilly' => "O'reilly",
             'van der saar' => 'van der Saar',
             'VAN LIER' => 'van Lier',
             'À Macdonald È' => 'A MacDonald E',

--- a/tests/Unit/SearchWordsTest.php
+++ b/tests/Unit/SearchWordsTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class SearchWordsTest extends TestCase
 {
-    private const HELLO_WORLD_LOWERCASE = 'hello world';
+    private const string HELLO_WORLD_LOWERCASE = 'hello world';
 
 
     /**

--- a/tests/Unit/StrReplaceTest.php
+++ b/tests/Unit/StrReplaceTest.php
@@ -14,34 +14,21 @@ use PHPUnit\Framework\TestCase;
  */
 final class StrReplaceTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private const LOVE_APPLE = 'I love apple.';
+    private const string LOVE_APPLE = 'I love apple.';
 
-    // Replace multiple occurrences of multiple characters
-    /**
-     * @var string[]
-     */
-    private const SEARCH = [
+    private const array SEARCH = [
         'H',
         'e',
         'W',
     ];
 
-    /**
-     * @var string[]
-     */
-    private const REPLACE = [
+    private const array REPLACE = [
         'h',
         'x',
         'w',
     ];
 
-    /**
-     * @var string
-     */
-    private const SUBJECT = 'Hello World';
+    private const string SUBJECT = 'Hello World';
 
 
     public function testStrReplaceWithNotFoundSearch(): void

--- a/tests/Unit/TrimTest.php
+++ b/tests/Unit/TrimTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class TrimTest extends TestCase
 {
-    private const DEFAULT_TRIM_CHARACTERS = " \t\n\r\0\x0B";
+    private const string DEFAULT_TRIM_CHARACTERS = " \t\n\r\0\x0B";
 
 
     /**

--- a/tests/Unit/Utf8AnsiTest.php
+++ b/tests/Unit/Utf8AnsiTest.php
@@ -14,10 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class Utf8AnsiTest extends TestCase
 {
-    /**
-     * @var array<string, string>
-     */
-    private const UTF8_TO_ANSI_MAP = [
+    private const array UTF8_TO_ANSI_MAP = [
         '\u00c0' => 'À',
         '\u00c1' => 'Á',
         '\u00c2' => 'Â',


### PR DESCRIPTION
### **User description**
## Summary

This merge request updates the project to require PHP 8.3 (removing support for PHP 8.2) and introduces explicit type declarations for constants in both source and test files. These changes improve overall code clarity, enhance performance by leveraging PHP 8.3 optimisations, and streamline maintenance efforts.

### Context and Background

Previously, the project allowed PHP 8.2 or higher. With the release and stabilisation of PHP 8.3, it is advantageous to align our configurations, documentation, and tooling to harness newer features and optimisations. Additionally, the codebase relied on docblocks to describe constant types, leading to potential ambiguity in code maintenance.

### Problem Description

1. **PHP 8.2 references**: The repository and CI workflows still referenced PHP 8.2, causing potential confusion for developers who have already adopted PHP 8.3.
2. **Implicit constant types**: Several constants in the codebase and tests used docblocks or provided no explicit type declarations, reducing type safety and clarity.

### Solution Description

1. **PHP 8.3 requirement**: All PHP version references, including GitHub workflows, composer.json, phpstan, phan, and Rector configurations, are updated to PHP 8.3. References to PHP 8.2 are removed to maintain consistency.
2. **Explicit type declarations**: Constants within both source and test files are prefixed with their explicit type (e.g. `private const string`, `private const array`). Redundant docblocks are removed, simplifying maintenance and ensuring consistent code expectations.

### List of Changes

- chore!: Require PHP 8.3, removing support for PHP 8.2
- style: Add explicit type declarations (e.g. `private const string`) for constants throughout the codebase
- style: Remove redundant docblocks and correct minor formatting issues


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Update project to require PHP 8.3, removing PHP 8.2 support.

- Add explicit type declarations for constants across source and test files.

- Update configuration files (e.g., `.phan/config.php`, `rector.php`) to align with PHP 8.3.

- Adjust CI workflows and documentation to reflect PHP 8.3 requirement.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>config.php</strong><dd><code>Update Phan configuration to target PHP 8.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-e7f458329acc571297877185ddc6ecb9ad7b2eb378528d14b15ffed48ab821b4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rector.php</strong><dd><code>Update Rector configuration to PHP 8.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-d933a2ad57daa43419b483d3f1ddedaec7aa44933007fead9f9437390f596f4a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codecov.yml</strong><dd><code>Update CI workflow to use PHP 8.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-512f30627f95d7fcdc76dc362d896351e9a4539994b7ab00b41979e653a6d0a9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>php.yml</strong><dd><code>Remove PHP 8.2 from CI matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-a73bb6555480a5ee79ae276a3f5d71a08fa316e09a4a8da7b643cf1e92c97df9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>phpstan.neon</strong><dd><code>Update PHPStan configuration to PHP 8.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>AccentNormalization.php</strong><dd><code>Add explicit type declarations for constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-e66a76efc704bd6d5c051cf14e2ff631cbe3277f3ebdee794a6e27916e5c992e">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UnicodeMappings.php</strong><dd><code>Add explicit type declarations for constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-f652b4cb3430bc8f15cf011cb5ec68af9ad9427c77cca398dd59880847a02b8b">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>StringManipulation.php</strong><dd><code>Minor formatting adjustments in doc comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-9b7b57239406d148f962899781e1a1d9309bc69b0ef75d1bf294fa5c3cf1aa3d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>IsValidDateTest.php</strong><dd><code>Add explicit type declarations for test constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-e286866f610d4f4c4094c127e315758da34c079b14a3120d036f834dd47a0ff9">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NameFixTest.php</strong><dd><code>Adjust test data for name handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-411e3d1cc26a08b44ff3a3061de251d40ff48352cada8c913356e4f6f16457e5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SearchWordsTest.php</strong><dd><code>Add explicit type declarations for test constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-cea6af0016612d7f90d4cb377b2379b144504d84a9d0df48a87f36fcadf06e5f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StrReplaceTest.php</strong><dd><code>Add explicit type declarations for test constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-76312ddbb6a1946b46940b6892a02538a47c72ca8139d11ab7f61129e73097da">+4/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TrimTest.php</strong><dd><code>Add explicit type declarations for test constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-75fb335ee2ed10310f08702d50e547d901a638e317ffee0438888da8f14b2499">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Utf8AnsiTest.php</strong><dd><code>Add explicit type declarations for test constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-a6e4dd55d4343c5c99b8029c1344bf8117e10cf1eafdd5f699aadf93ea62f4fa">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update system requirements to PHP 8.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>composer.json</strong><dd><code>Set minimum PHP requirement to 8.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MarjovanLier/StringManipulation/pull/43/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded CI workflows and build configurations to target PHP 8.3/8.4, streamlining the testing process.
  
- **Documentation**
  - Updated system requirements to mandate PHP 8.3 or later.
  
- **Tests**
  - Enhanced type declarations in test suites for improved clarity and reliability.
  
- **Refactor**
  - Improved internal code structure for enhanced type safety and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->